### PR TITLE
🐛 Fix Postgres db load scripts

### DIFF
--- a/PostgreSQL/OMOP CDM postgresql constraints.txt
+++ b/PostgreSQL/OMOP CDM postgresql constraints.txt
@@ -370,11 +370,11 @@ ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_source FOREIGN KEY (survey_
 
 ALTER TABLE survey_conduct ADD CONSTRAINT fpk_validation FOREIGN KEY (validated_survey_concept_id) REFERENCES concept (concept_id);
 
-ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_visit FOREIGN KEY (visit_occurrence_id) REFERENCES visit (visit_occurrence_id);
+ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_visit FOREIGN KEY (visit_occurrence_id) REFERENCES visit_occurrence (visit_occurrence_id);
 
 ALTER TABLE survey_conduct ADD CONSTRAINT fpk_survey_v_detail FOREIGN KEY (visit_detail_id) REFERENCES visit_detail (visit_detail_id);
 
-ALTER TABLE survey_conduct ADD CONSTRAINT fpk_response_visit FOREIGN KEY (response_visit_occurrence_id) REFERENCES visit (visit_occurrence_id);
+ALTER TABLE survey_conduct ADD CONSTRAINT fpk_response_visit FOREIGN KEY (response_visit_occurrence_id) REFERENCES visit_occurrence (visit_occurrence_id);
 
 
 ALTER TABLE fact_relationship ADD CONSTRAINT fpk_fact_domain_1 FOREIGN KEY (domain_concept_id_1)  REFERENCES concept (concept_id);

--- a/PostgreSQL/OMOP CDM postgresql constraints.txt
+++ b/PostgreSQL/OMOP CDM postgresql constraints.txt
@@ -167,14 +167,14 @@ ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_site_concept FOREIGN KEY (anato
 ALTER TABLE specimen ADD CONSTRAINT fpk_specimen_status_concept FOREIGN KEY (disease_status_concept_id)  REFERENCES concept (concept_id);
 
 
-ALTER TABLE death ADD CONSTRAINT fpk_death_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
+/*ALTER TABLE death ADD CONSTRAINT fpk_death_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
 
 ALTER TABLE death ADD CONSTRAINT fpk_death_type_concept FOREIGN KEY (death_type_concept_id)  REFERENCES concept (concept_id);
 
 ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept FOREIGN KEY (cause_concept_id)  REFERENCES concept (concept_id);
 
 ALTER TABLE death ADD CONSTRAINT fpk_death_cause_concept_s FOREIGN KEY (cause_source_concept_id)  REFERENCES concept (concept_id);
-
+*/
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_person FOREIGN KEY (person_id)  REFERENCES person (person_id);
 
@@ -188,7 +188,7 @@ ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_care_site FOREIGN KEY (car
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_concept_s FOREIGN KEY (visit_source_concept_id)  REFERENCES concept (concept_id);
 
-ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_admitting_s FOREIGN KEY (admitting_source_concept_id) REFERENCES concept (concept_id);
+ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_admitting_s FOREIGN KEY (admitted_from_concept_id) REFERENCES concept (concept_id);
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT fpk_visit_discharge FOREIGN KEY (discharge_to_concept_id) REFERENCES concept (concept_id);
 
@@ -207,7 +207,7 @@ ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_care_site FOREIGN KEY (care
 
 ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_discharge FOREIGN KEY (discharge_to_concept_id) REFERENCES concept (concept_id);
 
-ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_admitting_s FOREIGN KEY (admitting_source_concept_id) REFERENCES concept (concept_id);
+ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_admitting_s FOREIGN KEY (admitted_from_concept_id) REFERENCES concept (concept_id);
 
 ALTER TABLE visit_detail ADD CONSTRAINT fpk_v_detail_concept_s FOREIGN KEY (visit_detail_source_concept_id)  REFERENCES concept (concept_id);
 

--- a/PostgreSQL/OMOP CDM postgresql constraints.txt
+++ b/PostgreSQL/OMOP CDM postgresql constraints.txt
@@ -86,7 +86,7 @@ ALTER TABLE relationship ADD CONSTRAINT fpk_relationship_reverse FOREIGN KEY (re
 
 ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept FOREIGN KEY (concept_id)  REFERENCES concept (concept_id);
 
-ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept FOREIGN KEY (language_concept_id)  REFERENCES concept (concept_id);
+--ALTER TABLE concept_synonym ADD CONSTRAINT fpk_concept_synonym_concept FOREIGN KEY (language_concept_id)  REFERENCES concept (concept_id);
 
 
 ALTER TABLE concept_ancestor ADD CONSTRAINT fpk_concept_ancestor_concept_1 FOREIGN KEY (ancestor_concept_id)  REFERENCES concept (concept_id);

--- a/PostgreSQL/OMOP CDM postgresql ddl.txt
+++ b/PostgreSQL/OMOP CDM postgresql ddl.txt
@@ -211,9 +211,11 @@ CREATE TABLE metadata
 )
 ;
 
+/*
 INSERT INTO metadata (metadata_concept_id, metadata_type_concept_id, name, value_as_string, value_as_concept_id, metadata_date, metadata_datetime)
 VALUES (0, 0, 'CDM Version', '6.0', 0, NULL, NULL)
 ;
+*/
 
 
 /************************
@@ -226,7 +228,7 @@ Standardized clinical data
 --HINT DISTRIBUTE_ON_KEY(person_id)
 CREATE TABLE person
 (
-  person_id						BIGINT	  	NOT NULL , 
+  person_id						BIGINT	  	NOT NULL ,
   gender_concept_id				INTEGER	  	NOT NULL ,
   year_of_birth					INTEGER	  	NOT NULL ,
   month_of_birth				INTEGER	  	NULL,
@@ -298,7 +300,7 @@ CREATE TABLE visit_occurrence
   care_site_id					BIGINT			NULL,
   visit_source_value			VARCHAR(50)		NULL,
   visit_source_concept_id		INTEGER			NOT NULL ,
-  admitted_from_concept_id      INTEGER     	NOT NULL ,   
+  admitted_from_concept_id      INTEGER     	NOT NULL ,
   admitted_from_source_value    VARCHAR(50) 	NULL ,
   discharge_to_source_value		VARCHAR(50)		NULL ,
   discharge_to_concept_id		INTEGER   		NOT NULL ,
@@ -321,7 +323,7 @@ CREATE TABLE visit_detail
   provider_id                        BIGINT      NULL ,
   care_site_id                       BIGINT      NULL ,
   discharge_to_concept_id            INTEGER     NOT NULL ,
-  admitted_from_concept_id           INTEGER     NOT NULL , 
+  admitted_from_concept_id           INTEGER     NOT NULL ,
   admitted_from_source_value         VARCHAR(50) NULL ,
   visit_detail_source_value          VARCHAR(50) NULL ,
   visit_detail_source_concept_id     INTEGER     NOT NULL ,
@@ -349,7 +351,7 @@ CREATE TABLE procedure_occurrence
   visit_detail_id             	BIGINT      	NULL ,
   procedure_source_value		VARCHAR(50)		NULL ,
   procedure_source_concept_id	INTEGER			NOT NULL ,
-  modifier_source_value		    VARCHAR(50)		NULL 
+  modifier_source_value		    VARCHAR(50)		NULL
 )
 ;
 
@@ -461,8 +463,8 @@ CREATE TABLE note
 (
   note_id						BIGINT			NOT NULL ,
   person_id						BIGINT			NOT NULL ,
-  note_event_id         		BIGINT      	NULL , 
-  note_event_field_concept_id	INTEGER 		NOT NULL , 
+  note_event_id         		BIGINT      	NULL ,
+  note_event_field_concept_id	INTEGER 		NOT NULL ,
   note_date						DATE			NULL ,
   note_datetime					TIMESTAMP		NOT NULL ,
   note_type_concept_id			INTEGER			NOT NULL ,
@@ -521,15 +523,15 @@ CREATE TABLE observation
   observation_source_concept_id		INTEGER			NOT NULL ,
   unit_source_value				    VARCHAR(50)		NULL ,
   qualifier_source_value			VARCHAR(50)		NULL ,
-  observation_event_id				BIGINT			NULL , 
-  obs_event_field_concept_id		INTEGER			NOT NULL , 
+  observation_event_id				BIGINT			NULL ,
+  obs_event_field_concept_id		INTEGER			NOT NULL ,
   value_as_datetime					TIMESTAMP		NULL
 )
 ;
 
 
 --HINT DISTRIBUTE ON KEY(person_id)
-CREATE TABLE survey_conduct 
+CREATE TABLE survey_conduct
 (
   survey_conduct_id					BIGINT			NOT NULL ,
   person_id						    BIGINT			NOT NULL ,
@@ -603,7 +605,7 @@ CREATE TABLE location_history --Table added
 (
   location_history_id           BIGINT      NOT NULL ,
   location_id			        BIGINT		NOT NULL ,
-  relationship_type_concept_id	INTEGER		NOT NULL , 
+  relationship_type_concept_id	INTEGER		NOT NULL ,
   domain_id				        VARCHAR(50)	NOT NULL ,
   entity_id				        BIGINT		NOT NULL ,
   start_date			        DATE		NOT NULL ,
@@ -686,7 +688,7 @@ CREATE TABLE cost
   cost_id						BIGINT		NOT NULL ,
   person_id						BIGINT		NOT NULL,
   cost_event_id					BIGINT      NOT NULL ,
-  cost_event_field_concept_id	INTEGER		NOT NULL , 
+  cost_event_field_concept_id	INTEGER		NOT NULL ,
   cost_concept_id				INTEGER		NOT NULL ,
   cost_type_concept_id		  	INTEGER     NOT NULL ,
   currency_concept_id			INTEGER		NOT NULL ,

--- a/PostgreSQL/OMOP CDM postgresql pk indexes.txt
+++ b/PostgreSQL/OMOP CDM postgresql pk indexes.txt
@@ -101,7 +101,7 @@ ALTER TABLE observation_period ADD CONSTRAINT xpk_observation_period PRIMARY KEY
 
 ALTER TABLE specimen ADD CONSTRAINT xpk_specimen PRIMARY KEY ( specimen_id ) ;
 
-ALTER TABLE death ADD CONSTRAINT xpk_death PRIMARY KEY ( person_id ) ;
+--ALTER TABLE death ADD CONSTRAINT xpk_death PRIMARY KEY ( person_id ) ;
 
 ALTER TABLE visit_occurrence ADD CONSTRAINT xpk_visit_occurrence PRIMARY KEY ( visit_occurrence_id ) ;
 
@@ -253,8 +253,8 @@ CREATE INDEX idx_specimen_person_id  ON specimen  (person_id ASC);
 CLUSTER specimen  USING idx_specimen_person_id ;
 CREATE INDEX idx_specimen_concept_id ON specimen (specimen_concept_id ASC);
 
-CREATE INDEX idx_death_person_id  ON death  (person_id ASC);
-CLUSTER death  USING idx_death_person_id ;
+--CREATE INDEX idx_death_person_id  ON death  (person_id ASC);
+--CLUSTER death  USING idx_death_person_id ;
 
 CREATE INDEX idx_visit_person_id  ON visit_occurrence  (person_id ASC);
 CLUSTER visit_occurrence  USING idx_visit_person_id ;


### PR DESCRIPTION
There were several things in the Postgres db initialization scripts that were causing errors. Most of them seemed to be things that haven't been updated after changes in the OMOP data model (removal of death table, name changes of columns, etc). 

This PR attempts to fix the errors in 3 of the scripts (table creation, pk indexes, constraints). The Results script didn't have any issues.